### PR TITLE
chapter json, routing and embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 This repo is for tracking my progress in the [learn-go-with-tests](https://quii.gitbook.io/learn-go-with-tests/) course as I begin my quest to learn Go.
+
+## Chapter Reflections
+Reflections for `GO FUNDAMENTALS` can be found [here](docs/FUNDAMENTALS.md)
+
+Reflections for `BUILD AN APPLICATION` can be found [here](docs/APPLICATION.md)

--- a/docs/APPLICATION.md
+++ b/docs/APPLICATION.md
@@ -1,0 +1,16 @@
+# BUILD AN APPLICATION
+## Chapter 1 - Intro
+
+## Chapter 2 - HTTP Server
+See [http-server](../http-server)
+
+## Chapter 3 - JSON, Routing, & Embedding
+See [json](../json)
+
+## Chapter 4 - IO & Sorting
+
+## Chapter 5 - Command Line & Package Structure
+
+## Chapter 6 - Time
+
+## Chapter 7 - WebSockets

--- a/docs/FUNDAMENTALS.md
+++ b/docs/FUNDAMENTALS.md
@@ -1,0 +1,42 @@
+# GO FUNDAMENTALS
+## Chapter 1 - Install Go
+
+## Chapter 2 - Hello, World
+See [hello](../hello)
+
+## Chapter 3 - Integers
+See [integers](../integers)
+
+## Chapter 4 - Iteration
+See [iteration](../iteration)
+
+## Chapter 5 - Arrays and Slices
+See [arrays](../arrays)
+
+## Chapter 6 - Structs, Methods, & Interfaces
+See [structs](../structs)
+
+## Chapter 7 - Pointers & Errors
+See [pointers](../pointers)
+
+## Chapter 8 - Maps
+See [maps](../maps)
+
+## Chapter 9 - Dependency Injection
+See [dependencies](../dependencies)
+
+## Chapter 10 - Mocking
+See [mocking](../mocking)
+
+## Chapter 11 - Concurrency
+See [concurrency](../concurrency)
+
+## Chapter 12 - Select
+See [select](../select)
+
+## Chapter 13 - Reflection
+See [reflection](../reflection)
+
+## Chapter 14 - Sync
+
+## Chapter 15 - Context

--- a/json/InMemoryPlayerStore.go
+++ b/json/InMemoryPlayerStore.go
@@ -1,0 +1,25 @@
+package main
+
+func NewInMemoryPlayerStore() *InMemoryPlayerStore {
+	return &InMemoryPlayerStore{map[string]int{}}
+}
+
+type InMemoryPlayerStore struct {
+	store map[string]int
+}
+
+func (i *InMemoryPlayerStore) GetPlayerScore(name string) int {
+	return i.store[name]
+}
+
+func (i *InMemoryPlayerStore) RecordWin(name string) {
+	i.store[name]++
+}
+
+func (i *InMemoryPlayerStore) GetLeague() []Player {
+	var league []Player
+	for name, wins := range i.store {
+		league = append(league, Player{name, wins})
+	}
+	return league
+}

--- a/json/main.go
+++ b/json/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	server := NewPlayerServer(NewInMemoryPlayerStore())
+
+	if err := http.ListenAndServe(":5000", server); err != nil {
+		log.Fatalf("could not listen on port 5000 %v", err)
+	}
+}

--- a/json/server.go
+++ b/json/server.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type PlayerStore interface {
+	GetPlayerScore(name string) int
+	RecordWin(name string)
+	GetLeague() []Player
+}
+
+type PlayerServer struct {
+	store PlayerStore
+	http.Handler
+}
+
+type Player struct {
+	Name string
+	Wins int
+}
+
+func NewPlayerServer(store PlayerStore) *PlayerServer {
+	p := new(PlayerServer)
+
+	p.store = store
+
+	router := http.NewServeMux()
+	router.Handle("/league", http.HandlerFunc(p.leagueHandler))
+	router.Handle("/players/", http.HandlerFunc(p.playersHandler))
+
+	p.Handler = router
+
+	return p
+}
+
+func (p *PlayerServer) leagueHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("content-type", "application/json")
+	json.NewEncoder(w).Encode(p.store.GetLeague())
+	w.WriteHeader(http.StatusOK)
+}
+
+func (p *PlayerServer) playersHandler(w http.ResponseWriter, r *http.Request) {
+	player := r.URL.Path[len("/players/"):]
+
+	switch r.Method {
+	case http.MethodPost:
+		p.processWin(w, player)
+	case http.MethodGet:
+		p.showScore(w, player)
+	}
+}
+
+func (p *PlayerServer) showScore(w http.ResponseWriter, player string) {
+	score := p.store.GetPlayerScore(player)
+
+	if score == 0 {
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	fmt.Fprint(w, score)
+}
+
+func (p *PlayerServer) processWin(w http.ResponseWriter, player string) {
+	p.store.RecordWin(player)
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/json/server_integration_test.go
+++ b/json/server_integration_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecordAndRetrieveWins(t *testing.T) {
+	store := NewInMemoryPlayerStore()
+	server := NewPlayerServer(store)
+	player := "Pepper"
+
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+
+	t.Run("get score", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newGetScoreRequest(player))
+
+		assertResponseCode(t, response.Code, http.StatusOK)
+		assertResponseBody(t, response.Body.String(), "3")
+	})
+
+	t.Run("get league", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newLeagueRequest())
+		assertResponseCode(t, response.Code, http.StatusOK)
+
+		got := getLeagueFromResponse(t, response.Body)
+		want := []Player{
+			{"Pepper", 3},
+		}
+		assertLeague(t, got, want)
+	})
+}

--- a/json/server_test.go
+++ b/json/server_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+const jsonContentType = "application/json"
+
+func TestGETPlayers(t *testing.T) {
+	store := StubPlayerStore{
+		map[string]int{
+			"Pepper": 20,
+			"Floyd":  10,
+		},
+		nil,
+		nil,
+	}
+	server := NewPlayerServer(&store)
+
+	t.Run("returns Pepper's score", func(t *testing.T) {
+		request := newGetScoreRequest("Pepper")
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertResponseBody(t, response.Body.String(), "20")
+		assertResponseCode(t, response.Code, http.StatusOK)
+	})
+
+	t.Run("returns Floyd's score", func(t *testing.T) {
+		request := newGetScoreRequest("Floyd")
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertResponseBody(t, response.Body.String(), "10")
+		assertResponseCode(t, response.Code, http.StatusOK)
+	})
+
+	t.Run("return 404 on missing player", func(t *testing.T) {
+		request := newGetScoreRequest("Frank")
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertResponseCode(t, response.Code, http.StatusNotFound)
+	})
+}
+
+func TestStoreWins(t *testing.T) {
+	store := StubPlayerStore{
+		map[string]int{},
+		nil,
+		nil,
+	}
+	server := NewPlayerServer(&store)
+
+	t.Run("record a win when POST", func(t *testing.T) {
+		player := "Pepper"
+		request := newPostWinRequest(player)
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertResponseCode(t, response.Code, http.StatusAccepted)
+
+		if len(store.winCalls) != 1 {
+			t.Errorf("got %d calls to RecordWin, want %d", len(store.winCalls), 1)
+		}
+
+		if store.winCalls[0] != player {
+			t.Errorf("did not store correct winner, got '%s', want '%s'", store.winCalls[0], player)
+		}
+	})
+}
+
+func TestLeague(t *testing.T) {
+	t.Run("it returns 200 on /league", func(t *testing.T) {
+		wantedLeague := []Player{
+			{"Vinny", 32},
+			{"Dom", 20},
+			{"Bill", 19},
+		}
+
+		store := StubPlayerStore{nil, nil, wantedLeague}
+		server := NewPlayerServer(&store)
+
+		request := newLeagueRequest()
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		got := getLeagueFromResponse(t, response.Body)
+		assertResponseCode(t, response.Code, http.StatusOK)
+		assertLeague(t, got, wantedLeague)
+		assertContentType(t, response, jsonContentType)
+	})
+}
+
+type StubPlayerStore struct {
+	scores   map[string]int
+	winCalls []string
+	league   []Player
+}
+
+func (s *StubPlayerStore) GetPlayerScore(name string) int {
+	score := s.scores[name]
+	return score
+}
+
+func (s *StubPlayerStore) RecordWin(name string) {
+	s.winCalls = append(s.winCalls, name)
+}
+
+func (s *StubPlayerStore) GetLeague() []Player {
+	return s.league
+}
+
+func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	if response.Result().Header.Get("content-type") != want {
+		t.Errorf("response did not have content-type %s, got %v", want, response.Result().Header)
+	}
+}
+
+func assertResponseBody(t *testing.T, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("response body is wrong, got '%s', want '%s'", got, want)
+	}
+}
+
+func assertResponseCode(t *testing.T, got, want int) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("response code is wrong, got '%d', want '%d'", got, want)
+	}
+}
+
+func assertLeague(t *testing.T, got, want []Player) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
+	t.Helper()
+	err := json.NewDecoder(body).Decode(&league)
+
+	if err != nil {
+		t.Fatalf("Unable to parse response from server '%s' into slice of Player, '%v'", body, err)
+	}
+
+	return
+}
+
+func newGetScoreRequest(name string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/players/%s", name), nil)
+	return req
+}
+
+func newPostWinRequest(name string) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/players/%s", name), nil)
+	return req
+}
+
+func newLeagueRequest() *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, "/league", nil)
+	return req
+}


### PR DESCRIPTION
* Implement a `/league` endpoint
* use `NewServeMux` to serve multiple endpoints